### PR TITLE
Patch GetMachineCodePI to migrate from away from WMIC

### DIFF
--- a/Cryptolens.Licensing/SKMv3/Helpers.cs
+++ b/Cryptolens.Licensing/SKMv3/Helpers.cs
@@ -572,6 +572,18 @@ namespace SKM.V3.Methods
 
                         return SKGL.SKM.getSHA256(machineCodeSeed, v);
                     }
+                    else if (v==1)
+                    {
+                        var machineCodeSeed = ExecCommand("cmd.exe", "/c powershell.exe -Command \"(Get-CimInstance -Class Win32_ComputerSystemProduct).UUID\"", out error, v);
+                        machineCodeSeed = "UUID                                  " + machineCodeSeed + "  ";
+                        if (string.IsNullOrEmpty(machineCodeSeed) || !string.IsNullOrEmpty(error))
+                        {
+                            return null;
+                            //throw new Exception("Machine Code could not be computed. Error message: " + error);
+                        }
+
+                        return SKGL.SKM.getSHA256(machineCodeSeed, v);
+                    }
                     else
                     {
                         var machineCodeSeed = ExecCommand("cmd.exe", "/C wmic csproduct get uuid", out error, v);

--- a/SKM Test/TestMachineCode.cs
+++ b/SKM Test/TestMachineCode.cs
@@ -23,6 +23,7 @@ namespace SKM_Test
         {
             string mc = Helpers.GetMachineCodePI();
             string mc2 = Helpers.GetMachineCodePI(2);
+            string mc3 = Helpers.GetMachineCodePI(1);
         }
 
         [TestMethod]


### PR DESCRIPTION
Since WMIC is [deprecated starting from Windows 11](https://techcommunity.microsoft.com/t5/windows-it-pro-blog/wmi-command-line-wmic-utility-deprecation-next-steps/ba-p/4039242), we have released a new version of `GetMachineCodePI` that uses a Powershell interface to obtain the UUID instead of wmic.

For new projects, it's recommended to start with `Helpers.GetMachineCodePI(v: 2)`.

However, assuming that you were using `Helpers.GetMachineCodePI()` without supplying any version parameter, you can now call it using `Helpers.GetMachineCodePI(v: 10)` to obtain the same machine code as `Helpers.GetMachineCodePI()`. This way, the machine code will stay the same, which is especially useful if you already have customers using the old method in production.

We are not updating the original method, `Helpers.GetMachineCodePI()`, in case there are users that use an out of date version of Windows.